### PR TITLE
fix: corrigir caminho para leitura do arquivo JSON

### DIFF
--- a/src/main/java/com/yuricavalcante/challenge/cli/CliApplication.java
+++ b/src/main/java/com/yuricavalcante/challenge/cli/CliApplication.java
@@ -39,7 +39,7 @@ public class CliApplication {
 		Node transporte = null;
 		try {
 			// Lê o JSON do arquivo localizado em src/main/resources/transporte.json
-			String jsonString = new String(Files.readAllBytes(Paths.get("src/main/java/com.yuricavalcante.challenge.cli/dicts/arvore.json")));
+			String jsonString = new String(Files.readAllBytes(Paths.get("src/main/java/com/yuricavalcante/challenge/cli/dicts/arvore.json")));
 			transporte = JsonTreeBuilder.buildFromJson(jsonString);
 		} catch (IOException e) {
 			e.printStackTrace();


### PR DESCRIPTION
- Corrigido o caminho do arquivo JSON no método de leitura da árvore.
- Atualizado de 'src/main/java/com.yuricavalcante.challenge.cli/dicts/arvore.json' para 'src/main/java/com/yuricavalcante/challenge/cli/dicts/arvore.json' para seguir o padrão de diretórios correto do projeto.
- Garante que o arquivo JSON seja lido corretamente durante a execução da CLI.